### PR TITLE
[#88473290] Added default css styles for sorting in smart-table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
         "leanIX"
     ],
     "description": "table module for angular",
-    "main": "dist/smart-table.js",
+    "main": ["dist/smart-table.js", "dist/smart-table.css"],
     "keywords": [
         "smart-table",
         "angular",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "leanix-smart-table",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "homepage": "https://github.com/leanix/leanix-smart-table",
     "authors": [
         "lorenzofox3 <laurent34azerty@gmail.com>",

--- a/dist/smart-table.css
+++ b/dist/smart-table.css
@@ -1,0 +1,24 @@
+/*--- Global SmartTable styles ----------------------------------------------*/
+.st-sort-ascent:after {
+  position: relative;
+  bottom: 10px;
+  left: 5px;
+  content: "";
+  border: 4px solid transparent;
+  border-bottom-color: black;
+}
+.st-sort-descent:after {
+  position: relative;
+  top: 12px;
+  left: 5px;
+  content: "";
+  border: 4px solid transparent;
+  border-top-color: black;
+}
+th[st-sort] {
+  cursor: pointer;
+  color: #028512;
+}
+th[st-sort]:hover {
+  text-decoration: underline;
+}

--- a/gulpFile.js
+++ b/gulpFile.js
@@ -49,9 +49,16 @@ gulp.task('concat', function () {
         .pipe(gulp.dest(disFolder));
 });
 
+gulp.task('copy-css', function () {
+    gulp.src('src/smart-table.css')
+        .pipe(gulp.dest(disFolder));
+});
+
 gulp.task('test', ['karma-CI']);
 
-gulp.task('build',['test', 'uglify', 'concat'], function () {
+gulp.task('default', ['build']);
+
+gulp.task('build',['test', 'uglify', 'concat', 'copy-css'], function () {
 
     var version = packageJson.version;
     var string = '/** \n* @version ' + version + '\n* @license MIT\n*/\n';

--- a/src/smart-table.css
+++ b/src/smart-table.css
@@ -1,0 +1,24 @@
+/*--- Global SmartTable styles ----------------------------------------------*/
+.st-sort-ascent:after {
+  position: relative;
+  bottom: 10px;
+  left: 5px;
+  content: "";
+  border: 4px solid transparent;
+  border-bottom-color: black;
+}
+.st-sort-descent:after {
+  position: relative;
+  top: 12px;
+  left: 5px;
+  content: "";
+  border: 4px solid transparent;
+  border-top-color: black;
+}
+th[st-sort] {
+  cursor: pointer;
+  color: #028512;
+}
+th[st-sort]:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
I have included the leanix-smart-table for the new synclog feature and wondered why the sort direction is not displayed. The reason was that this is done by styling, so i decided to add a few default styles.
